### PR TITLE
Integrate CSV import into admin dashboard

### DIFF
--- a/frontend/src/app/layout/sidebar/sidebar.component.ts
+++ b/frontend/src/app/layout/sidebar/sidebar.component.ts
@@ -41,7 +41,6 @@ export class SidebarComponent {
     { label: 'Professors', icon: 'groups', route: '/professors', roles: [Role.PROFESSOR, Role.AV, Role.SYS_ADMIN] },
     { label: 'Create Professor', icon: 'person_add', route: '/professors/create', roles: [Role.AV, Role.SYS_ADMIN] },
     { label: 'Admin Dashboard', icon: 'admin_panel_settings', route: '/admin-dashboard', roles: [Role.SYS_ADMIN, Role.AV] },
-    { label: 'Import', icon: 'upload_file', route: '/import', roles: [Role.SYS_ADMIN, Role.AV] },
     { label: 'Profile', icon: 'person', route: '/profile' }
   ];
 

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.html
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.html
@@ -192,11 +192,16 @@
       </mat-card>
     </div>
 
+    <!-- CSV Import -->
+    <section id="csv-import" class="csv-import-section">
+      <app-import></app-import>
+    </section>
+
     <!-- Quick Actions -->
     <div class="admin-actions">
       <h3>Administrator Aktionen</h3>
       <div class="actions-grid">
-        <button mat-raised-button color="primary" routerLink="/import" class="action-button">
+        <button mat-raised-button color="primary" class="action-button" (click)="scrollToImportSection()">
           <mat-icon>upload_file</mat-icon>
           <span>Daten Importieren</span>
         </button>
@@ -221,35 +226,6 @@
           <span>Einstellungen</span>
         </button>
       </div>
-    </div>
-    
-    <!-- Klassen Dashboard -->
-    <div class="classes-dashboard" *ngIf="classDashboard$ | async as years">
-      <mat-card class="section-card">
-        <mat-card-header>
-          <mat-card-title>Klassenübersicht nach Schuljahr</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-          <div class="years-list">
-            <div *ngFor="let y of years" class="year-block">
-              <h3>{{ y.year }}</h3>
-              <div class="classes-list">
-                <div *ngFor="let c of y.classes" class="class-card">
-                  <div class="class-header">
-                    <div class="class-name">{{ c.name }}</div>
-                    <div class="class-branch">{{ c.branch }}</div>
-                    <div class="class-count">{{ c.students.length }} Schüler</div>
-                  </div>
-                  <div class="students-list">
-                    <div *ngFor="let s of c.students" class="student-line">{{ s.lastName }}, {{ s.firstName }}</div>
-                    <div *ngIf="c.students.length === 0" class="empty">keine Schüler</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </mat-card-content>
-      </mat-card>
     </div>
   </div>
 </div>

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.scss
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.scss
@@ -199,54 +199,6 @@
   }
 }
 
-.classes-dashboard {
-  margin-top: 20px;
-
-  .years-list {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 16px;
-  }
-
-  .year-block {
-    margin-bottom: 8px;
-
-    h3 {
-      margin: 0 0 8px 0;
-      font-size: 18px;
-    }
-
-    .classes-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 12px;
-    }
-
-    .class-card {
-      padding: 12px;
-      border-radius: 6px;
-      background: #fff;
-      box-shadow: 0 1px 6px rgba(0,0,0,0.06);
-
-      .class-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        gap: 8px;
-        margin-bottom: 8px;
-
-        .class-name { font-weight: 600; }
-        .class-branch { color: rgba(0,0,0,0.6); font-size: 12px; }
-        .class-count { font-size: 12px; color: rgba(0,0,0,0.7); }
-      }
-
-      .students-list { font-size: 13px; color: rgba(0,0,0,0.8); }
-      .student-line { padding: 2px 0; }
-      .empty { color: rgba(0,0,0,0.5); font-style: italic; }
-    }
-  }
-}
-
 // Bar Chart Styles
 .diagram-container {
   display: grid;
@@ -648,4 +600,9 @@
   .trends-section {
     grid-template-columns: 1fr;
   }
+}
+
+.csv-import-section {
+  margin: 32px 0;
+  scroll-margin-top: 24px;
 }

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.ts
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.ts
@@ -1,35 +1,12 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { AdminService, AdminStats, TrendData } from '../../services/admin.service';
-import { SchoolYear } from '../../core/models';
-import { SchoolYearService } from '../../services/schoolyear.service';
-import { StudentService } from '../../services/student.service';
-import { Observable, combineLatest, map, shareReplay } from 'rxjs';
-import { Class, StudentProfile } from '../../core/models';
-
-interface ClassStudentEntry {
-  id: string;
-  firstName: string;
-  lastName: string;
-  historyId: number;
-}
-
-interface ClassDashboardItem {
-  classId: string;
-  name: string;
-  branch: string;
-  students: ClassStudentEntry[];
-}
-
-interface SchoolYearDashboardItem {
-  schoolYearId: string;
-  year: string;
-  classes: ClassDashboardItem[];
-}
+import { ImportComponent } from '../import/import.component';
+import { Observable } from 'rxjs';
 
 /**
  * Admin Dashboard Component
@@ -43,112 +20,17 @@ interface SchoolYearDashboardItem {
     RouterModule,
     MatCardModule,
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    ImportComponent
   ],
   templateUrl: './admin-dashboard.component.html',
   styleUrl: './admin-dashboard.component.scss'
 })
 export class AdminDashboardComponent {
   private readonly adminService = inject(AdminService);
-  private readonly schoolYearService = inject(SchoolYearService);
-  private readonly studentService = inject(StudentService);
 
   stats$: Observable<AdminStats> = this.adminService.getAdminStats();
   trendData$: Observable<TrendData> = this.adminService.getTrendData();
-  classDashboard$: Observable<SchoolYearDashboardItem[]> = combineLatest([
-    this.schoolYearService.getSchoolYears(),
-    this.studentService.getClasses(),
-    this.studentService.getStudents()
-  ]).pipe(
-    map(([schoolYears, classes, students]) => this.buildClassDashboard(schoolYears, classes, students)),
-    shareReplay(1)
-  );
-
-  private buildClassDashboard(
-    schoolYears: SchoolYear[],
-    classes: Class[],
-    students: StudentProfile[]
-  ): SchoolYearDashboardItem[] {
-    const classLookup = new Map(classes.map(studentClass => [studentClass.id, studentClass]));
-    const years = new Map<string, SchoolYearDashboardItem>();
-
-    schoolYears.forEach(schoolYear => {
-      years.set(schoolYear.id, {
-        schoolYearId: schoolYear.id,
-        year: schoolYear.year,
-        classes: []
-      });
-    });
-
-    const yearClassBuckets = new Map<string, Map<string, ClassDashboardItem & { studentIds: Set<string> }>>();
-
-    const ensureYear = (schoolYearId: string, fallbackYearLabel?: string) => {
-      if (!years.has(schoolYearId)) {
-        years.set(schoolYearId, {
-          schoolYearId,
-          year: fallbackYearLabel || schoolYearId,
-          classes: []
-        });
-      }
-
-      if (!yearClassBuckets.has(schoolYearId)) {
-        yearClassBuckets.set(schoolYearId, new Map());
-      }
-
-      return years.get(schoolYearId)!;
-    };
-
-    students.forEach(student => {
-      const histories = student.histories || [];
-      histories.forEach(history => {
-        const schoolYearId = String(history.schoolYearId);
-        const yearBucket = ensureYear(schoolYearId, history.schoolYear);
-        const classBucketMap = yearClassBuckets.get(schoolYearId)!;
-        const classId = String(history.classId);
-
-        if (!classBucketMap.has(classId)) {
-          const classEntity = classLookup.get(classId);
-          classBucketMap.set(classId, {
-            classId,
-            name: history.className || classEntity?.name || `Klasse ${classId}`,
-            branch: history.branch || classEntity?.branch || '',
-            students: [],
-            studentIds: new Set<string>()
-          });
-        }
-
-        const bucket = classBucketMap.get(classId)!;
-        if (!bucket.studentIds.has(student.id)) {
-          bucket.studentIds.add(student.id);
-          bucket.students.push({
-            id: student.id,
-            firstName: student.firstName,
-            lastName: student.lastName,
-            historyId: history.historyId
-          });
-        }
-
-        yearBucket.classes = Array.from(classBucketMap.values())
-          .map(({ studentIds, ...classItem }) => classItem)
-          .sort((a, b) => this.sortText(a.branch || a.name, b.branch || b.name));
-      });
-    });
-
-    return Array.from(years.values())
-      .sort((a, b) => this.sortText(b.year, a.year))
-      .map(year => ({
-        ...year,
-        classes: year.classes
-          .map(classItem => ({
-            ...classItem,
-            students: [...classItem.students].sort((a, b) => this.sortText(`${a.lastName} ${a.firstName}`, `${b.lastName} ${b.firstName}`))
-          }))
-      }));
-  }
-
-  private sortText(left: string, right: string): number {
-    return left.localeCompare(right, 'de', { numeric: true, sensitivity: 'base' });
-  }
 
   generateLinePath(data: { year: string; value: number }[], width: number, height: number, padding: number): string {
     if (!data || data.length === 0) return '';
@@ -203,4 +85,9 @@ export class AdminDashboardComponent {
     const plotHeight = height - 2 * padding;
     return [0, 1, 2, 3, 4].map(index => padding + (plotHeight / 4) * index);
   }
+
+  scrollToImportSection(): void {
+    document.getElementById('csv-import')?.scrollIntoView({ behavior: 'smooth' });
+  }
 }
+

--- a/frontend/src/app/pages/import/import.component.html
+++ b/frontend/src/app/pages/import/import.component.html
@@ -1,207 +1,266 @@
-    <div class="page-container">
-      <div class="page-header">
-        <h1>Import Data</h1>
+<div class="page-container">
+  <div class="page-header">
+    <h1>CSV-Import</h1>
+    <p class="header-subtitle">Schüler und Professoren zentral im Admin-Dashboard importieren</p>
+  </div>
+
+  <mat-tab-group>
+    <!-- Import Students Tab -->
+    <mat-tab label="Schüler importieren">
+      <div class="tab-content">
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title>Schüler importieren</mat-card-title>
+            <mat-card-subtitle>CSV-Datei hochladen und Schüler importieren</mat-card-subtitle>
+          </mat-card-header>
+
+          <mat-card-content>
+            <div class="import-instructions">
+              <mat-icon>info</mat-icon>
+              <div>
+                <p><strong>Anleitung:</strong></p>
+                <ul>
+                  <li>Template herunterladen und mit den Schülerdaten befüllen</li>
+                  <li>Alle Pflichtfelder ausfüllen</li>
+                  <li>Datei als CSV speichern</li>
+                  <li>CSV-Datei auswählen und nach der Vorschau importieren</li>
+                </ul>
+              </div>
+            </div>
+
+            <button mat-raised-button (click)="downloadTemplate(ImportType.STUDENTS)">
+              <mat-icon>download</mat-icon>
+              CSV-Template herunterladen
+            </button>
+
+            <div class="file-upload">
+              <input
+                type="file"
+                accept=".csv"
+                (change)="handleFileInput($event, ImportType.STUDENTS)"
+                #fileInputStudents
+                style="display: none;">
+
+              <button mat-raised-button color="accent" (click)="fileInputStudents.click()">
+                <mat-icon>upload_file</mat-icon>
+                CSV-Datei auswählen
+              </button>
+
+              <span class="file-name" *ngIf="selectedFile() as file">
+                <ng-container *ngIf="currentImportType() === ImportType.STUDENTS">
+                  {{ file.name }}
+                </ng-container>
+              </span>
+            </div>
+
+            <div class="validation-result" *ngIf="validation() as currentValidation">
+              <ng-container *ngIf="currentImportType() === ImportType.STUDENTS">
+                <div class="validation-header" [class.valid]="currentValidation.isValid" [class.invalid]="!currentValidation.isValid">
+                  <mat-icon>{{ currentValidation.isValid ? 'check_circle' : 'error' }}</mat-icon>
+                  <span>{{ currentValidation.isValid ? 'Datei ist gültig' : 'Validierungsfehler gefunden' }}</span>
+                </div>
+
+                <div class="errors" *ngIf="currentValidation.errors && currentValidation.errors.length > 0">
+                  <h4>Fehler:</h4>
+                  <ul>
+                    <li *ngFor="let error of currentValidation.errors">
+                      Zeile {{ error.row }}: {{ error.message }}
+                    </li>
+                  </ul>
+                </div>
+
+                <div class="preview" *ngIf="currentValidation.preview">
+                  <h4>Vorschau der ersten 10 Zeilen:</h4>
+                  <table class="preview-table">
+                    <thead>
+                      <tr>
+                        <th *ngFor="let header of currentValidation.preview.headers">{{ header }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr *ngFor="let row of currentValidation.preview.rows">
+                        <td *ngFor="let cell of row">{{ cell }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p class="total-rows">Zeilen gesamt: {{ currentValidation.preview.totalRows }}</p>
+                </div>
+              </ng-container>
+            </div>
+
+            <div class="import-result" *ngIf="importResult() as result">
+              <ng-container *ngIf="importResultType() === ImportType.STUDENTS">
+                <div class="result-header">
+                  <mat-icon>task_alt</mat-icon>
+                  <span>Import-Ergebnis</span>
+                </div>
+
+                <div class="result-summary">
+                  <div><strong>Gesamt:</strong> {{ result.totalRows }}</div>
+                  <div><strong>Importiert:</strong> {{ result.importedCount }}</div>
+                  <div><strong>Übersprungen:</strong> {{ result.skippedCount }}</div>
+                  <div><strong>Fehlgeschlagen:</strong> {{ result.failedCount }}</div>
+                </div>
+
+                <div class="result-rows" *ngIf="result.rows && result.rows.length > 0">
+                  <h4>Details:</h4>
+                  <ul>
+                    <li *ngFor="let row of result.rows">
+                      Zeile {{ row.rowNumber }}: {{ row.status }}
+                      <span *ngIf="row.identifier">({{ row.identifier }})</span>
+                      <span *ngIf="row.reason">- {{ row.reason }}</span>
+                    </li>
+                  </ul>
+                </div>
+              </ng-container>
+            </div>
+
+            <mat-progress-bar mode="indeterminate" *ngIf="importing()"></mat-progress-bar>
+          </mat-card-content>
+
+          <mat-card-actions>
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="!validation() || !validation()?.isValid || importing() || currentImportType() !== ImportType.STUDENTS"
+              (click)="performImport(ImportType.STUDENTS)">
+              {{ importing() ? 'Import läuft...' : 'Daten importieren' }}
+            </button>
+            <button mat-button (click)="reset()" [disabled]="importing()">
+              Zurücksetzen
+            </button>
+          </mat-card-actions>
+        </mat-card>
       </div>
+    </mat-tab>
 
-      <mat-tab-group>
-        <!-- Import Students Tab -->
-        <mat-tab label="Import Students">
-          <div class="tab-content">
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Import Students</mat-card-title>
-                <mat-card-subtitle>Upload a CSV file to import students</mat-card-subtitle>
-              </mat-card-header>
+    <!-- Import Professors Tab -->
+    <mat-tab label="Professoren importieren">
+      <div class="tab-content">
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title>Professoren importieren</mat-card-title>
+            <mat-card-subtitle>CSV-Datei hochladen und Professoren importieren</mat-card-subtitle>
+          </mat-card-header>
 
-              <mat-card-content>
-                <div class="import-instructions">
-                  <mat-icon>info</mat-icon>
-                  <div>
-                    <p><strong>Instructions:</strong></p>
-                    <ul>
-                      <li>Download the template file and fill in your data</li>
-                      <li>Ensure all required fields are filled</li>
-                      <li>Save as CSV format</li>
-                      <li>Upload the file below</li>
-                    </ul>
-                  </div>
+          <mat-card-content>
+            <div class="import-instructions">
+              <mat-icon>info</mat-icon>
+              <div>
+                <p><strong>Anleitung:</strong></p>
+                <ul>
+                  <li>Template herunterladen und mit den Professorendaten befüllen</li>
+                  <li>Alle Pflichtfelder ausfüllen</li>
+                  <li>Datei als CSV speichern</li>
+                  <li>CSV-Datei auswählen und nach der Vorschau importieren</li>
+                </ul>
+              </div>
+            </div>
+
+            <button mat-raised-button (click)="downloadTemplate(ImportType.TEACHERS)">
+              <mat-icon>download</mat-icon>
+              CSV-Template herunterladen
+            </button>
+
+            <div class="file-upload">
+              <input
+                type="file"
+                accept=".csv"
+                (change)="handleFileInput($event, ImportType.TEACHERS)"
+                #fileInputTeachers
+                style="display: none;">
+
+              <button mat-raised-button color="accent" (click)="fileInputTeachers.click()">
+                <mat-icon>upload_file</mat-icon>
+                CSV-Datei auswählen
+              </button>
+
+              <span class="file-name" *ngIf="selectedFile() as file">
+                <ng-container *ngIf="currentImportType() === ImportType.TEACHERS">
+                  {{ file.name }}
+                </ng-container>
+              </span>
+            </div>
+
+            <div class="validation-result" *ngIf="validation() as currentValidation">
+              <ng-container *ngIf="currentImportType() === ImportType.TEACHERS">
+                <div class="validation-header" [class.valid]="currentValidation.isValid" [class.invalid]="!currentValidation.isValid">
+                  <mat-icon>{{ currentValidation.isValid ? 'check_circle' : 'error' }}</mat-icon>
+                  <span>{{ currentValidation.isValid ? 'Datei ist gültig' : 'Validierungsfehler gefunden' }}</span>
                 </div>
 
-                <button mat-raised-button (click)="downloadTemplate(ImportType.STUDENTS)">
-                  <mat-icon>download</mat-icon>
-                  Download Template
-                </button>
-
-                
-
-                <div class="file-upload">
-                  <input 
-                    type="file" 
-                    accept=".csv"
-                    (change)="handleFileInput($event, ImportType.STUDENTS)"
-                    #fileInputStudents
-                    style="display: none;">
-                  
-                  <button mat-raised-button color="accent" (click)="fileInputStudents.click()">
-                    <mat-icon>upload_file</mat-icon>
-                    Choose CSV File
-                  </button>
-
-                  <span class="file-name" *ngIf="selectedFile() as file">{{ file.name }}</span>
+                <div class="errors" *ngIf="currentValidation.errors && currentValidation.errors.length > 0">
+                  <h4>Fehler:</h4>
+                  <ul>
+                    <li *ngFor="let error of currentValidation.errors">
+                      Zeile {{ error.row }}: {{ error.message }}
+                    </li>
+                  </ul>
                 </div>
 
-                <div class="validation-result" *ngIf="validation() as currentValidation">
-                  <ng-container *ngIf="currentImportType() === ImportType.STUDENTS">
-                  <div class="validation-header" [class.valid]="currentValidation.isValid" [class.invalid]="!currentValidation.isValid">
-                    <mat-icon>{{ currentValidation.isValid ? 'check_circle' : 'error' }}</mat-icon>
-                    <span>{{ currentValidation.isValid ? 'File is valid' : 'Validation errors found' }}</span>
-                  </div>
+                <div class="preview" *ngIf="currentValidation.preview">
+                  <h4>Vorschau der ersten 10 Zeilen:</h4>
+                  <table class="preview-table">
+                    <thead>
+                      <tr>
+                        <th *ngFor="let header of currentValidation.preview.headers">{{ header }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr *ngFor="let row of currentValidation.preview.rows">
+                        <td *ngFor="let cell of row">{{ cell }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p class="total-rows">Zeilen gesamt: {{ currentValidation.preview.totalRows }}</p>
+                </div>
+              </ng-container>
+            </div>
 
-                  <div class="errors" *ngIf="currentValidation.errors && currentValidation.errors.length > 0">
-                    <h4>Errors:</h4>
-                    <ul>
-                      <li *ngFor="let error of currentValidation.errors">
-                        Row {{ error.row }}: {{ error.message }}
-                      </li>
-                    </ul>
-                  </div>
-
-                  <div class="preview" *ngIf="currentValidation.preview">
-                    <h4>Preview (first 10 rows):</h4>
-                    <table class="preview-table">
-                      <thead>
-                        <tr>
-                          <th *ngFor="let header of currentValidation.preview.headers">{{ header }}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr *ngFor="let row of currentValidation.preview.rows">
-                          <td *ngFor="let cell of row">{{ cell }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <p class="total-rows">Total rows: {{ currentValidation.preview.totalRows }}</p>
-                  </div>
-                  </ng-container>
+            <div class="import-result" *ngIf="importResult() as result">
+              <ng-container *ngIf="importResultType() === ImportType.TEACHERS">
+                <div class="result-header">
+                  <mat-icon>task_alt</mat-icon>
+                  <span>Import-Ergebnis</span>
                 </div>
 
-                <mat-progress-bar mode="indeterminate" *ngIf="importing()"></mat-progress-bar>
-              </mat-card-content>
-
-              <mat-card-actions>
-                <button 
-                  mat-raised-button 
-                  color="primary"
-                  [disabled]="!validation() || !validation()?.isValid || importing() || currentImportType() !== ImportType.STUDENTS"
-                  (click)="performImport(ImportType.STUDENTS)">
-                  {{ importing() ? 'Importing...' : 'Import Data' }}
-                </button>
-                <button mat-button (click)="reset()" [disabled]="importing()">
-                  Reset
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          </div>
-        </mat-tab>
-
-        <!-- Import Professors Tab -->
-        <mat-tab label="Import Professors">
-          <div class="tab-content">
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Import Professors</mat-card-title>
-                <mat-card-subtitle>Upload a CSV file to import professors</mat-card-subtitle>
-              </mat-card-header>
-
-              <mat-card-content>
-                <div class="import-instructions">
-                  <mat-icon>info</mat-icon>
-                  <div>
-                    <p><strong>Instructions:</strong></p>
-                    <ul>
-                      <li>Download the template file and fill in your data</li>
-                      <li>Ensure all required fields are filled</li>
-                      <li>Save as CSV format</li>
-                      <li>Upload the file below</li>
-                    </ul>
-                  </div>
+                <div class="result-summary">
+                  <div><strong>Gesamt:</strong> {{ result.totalRows }}</div>
+                  <div><strong>Importiert:</strong> {{ result.importedCount }}</div>
+                  <div><strong>Übersprungen:</strong> {{ result.skippedCount }}</div>
+                  <div><strong>Fehlgeschlagen:</strong> {{ result.failedCount }}</div>
                 </div>
 
-                <button mat-raised-button (click)="downloadTemplate(ImportType.TEACHERS)">
-                  <mat-icon>download</mat-icon>
-                  Download Template
-                </button>
-
-                <div class="file-upload">
-                  <input 
-                    type="file" 
-                    accept=".csv"
-                    (change)="handleFileInput($event, ImportType.TEACHERS)"
-                    #fileInputTeachers
-                    style="display: none;">
-                  
-                  <button mat-raised-button color="accent" (click)="fileInputTeachers.click()">
-                    <mat-icon>upload_file</mat-icon>
-                    Choose CSV File
-                  </button>
-
-                  <span class="file-name" *ngIf="selectedFile() as file">{{ file.name }}</span>
+                <div class="result-rows" *ngIf="result.rows && result.rows.length > 0">
+                  <h4>Details:</h4>
+                  <ul>
+                    <li *ngFor="let row of result.rows">
+                      Zeile {{ row.rowNumber }}: {{ row.status }}
+                      <span *ngIf="row.identifier">({{ row.identifier }})</span>
+                      <span *ngIf="row.reason">- {{ row.reason }}</span>
+                    </li>
+                  </ul>
                 </div>
+              </ng-container>
+            </div>
 
-                <div class="validation-result" *ngIf="validation() as currentValidation">
-                  <ng-container *ngIf="currentImportType() === ImportType.TEACHERS">
-                  <div class="validation-header" [class.valid]="currentValidation.isValid" [class.invalid]="!currentValidation.isValid">
-                    <mat-icon>{{ currentValidation.isValid ? 'check_circle' : 'error' }}</mat-icon>
-                    <span>{{ currentValidation.isValid ? 'File is valid' : 'Validation errors found' }}</span>
-                  </div>
+            <mat-progress-bar mode="indeterminate" *ngIf="importing()"></mat-progress-bar>
+          </mat-card-content>
 
-                  <div class="errors" *ngIf="currentValidation.errors && currentValidation.errors.length > 0">
-                    <h4>Errors:</h4>
-                    <ul>
-                      <li *ngFor="let error of currentValidation.errors">
-                        Row {{ error.row }}: {{ error.message }}
-                      </li>
-                    </ul>
-                  </div>
-
-                  <div class="preview" *ngIf="currentValidation.preview">
-                    <h4>Preview (first 10 rows):</h4>
-                    <table class="preview-table">
-                      <thead>
-                        <tr>
-                          <th *ngFor="let header of currentValidation.preview.headers">{{ header }}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr *ngFor="let row of currentValidation.preview.rows">
-                          <td *ngFor="let cell of row">{{ cell }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <p class="total-rows">Total rows: {{ currentValidation.preview.totalRows }}</p>
-                  </div>
-                  </ng-container>
-                </div>
-
-                <mat-progress-bar mode="indeterminate" *ngIf="importing()"></mat-progress-bar>
-              </mat-card-content>
-
-              <mat-card-actions>
-                <button 
-                  mat-raised-button 
-                  color="primary"
-                  [disabled]="!validation() || !validation()?.isValid || importing() || currentImportType() !== ImportType.TEACHERS"
-                  (click)="performImport(ImportType.TEACHERS)">
-                  {{ importing() ? 'Importing...' : 'Import Data' }}
-                </button>
-                <button mat-button (click)="reset()" [disabled]="importing()">
-                  Reset
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          </div>
-        </mat-tab>
-
-      </mat-tab-group>
-    </div>
-  
+          <mat-card-actions>
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="!validation() || !validation()?.isValid || importing() || currentImportType() !== ImportType.TEACHERS"
+              (click)="performImport(ImportType.TEACHERS)">
+              {{ importing() ? 'Import läuft...' : 'Daten importieren' }}
+            </button>
+            <button mat-button (click)="reset()" [disabled]="importing()">
+              Zurücksetzen
+            </button>
+          </mat-card-actions>
+        </mat-card>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/frontend/src/app/pages/import/import.component.scss
+++ b/frontend/src/app/pages/import/import.component.scss
@@ -1,133 +1,190 @@
-    .tab-content {
-      padding: 24px 0;
+.page-container {
+  padding: 0;
+}
+
+.page-header {
+  margin-bottom: 24px;
+
+  h1 {
+    font-size: 28px;
+    font-weight: 400;
+    margin: 0 0 8px 0;
+  }
+
+  .header-subtitle {
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+    margin: 0;
+  }
+}
+
+.tab-content {
+  padding: 24px 0;
+}
+
+.import-instructions {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  background: #e3f2fd;
+  border-radius: 4px;
+  margin-bottom: 24px;
+
+  mat-icon {
+    color: #1976d2;
+  }
+
+  ul {
+    margin: 8px 0;
+    padding-left: 20px;
+  }
+}
+
+.file-upload {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin: 24px 0;
+
+  .file-name {
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+}
+
+.validation-result,
+.import-result {
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+
+  h4 {
+    font-size: 14px;
+    font-weight: 500;
+    margin: 16px 0 8px 0;
+  }
+}
+
+.validation-result {
+  .validation-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    margin-bottom: 16px;
+
+    &.valid {
+      color: #388e3c;
     }
 
-    .import-instructions {
-      display: flex;
-      gap: 16px;
-      padding: 16px;
-      background: #e3f2fd;
-      border-radius: 4px;
-      margin-bottom: 24px;
-
-      mat-icon {
-        color: #1976d2;
-      }
-
-      ul {
-        margin: 8px 0;
-        padding-left: 20px;
-      }
+    &.invalid {
+      color: #d32f2f;
     }
+  }
 
-    .file-upload {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      margin: 24px 0;
-
-      .file-name {
-        font-size: 14px;
-        color: rgba(0, 0, 0, 0.6);
-      }
+  .errors {
+    ul {
+      margin: 0;
+      padding-left: 20px;
+      color: #d32f2f;
     }
+  }
+}
 
-    .validation-result {
-      margin: 24px 0;
-      padding: 16px;
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+
+  th,
+  td {
+    border: 1px solid #e0e0e0;
+    padding: 8px;
+    text-align: left;
+    font-size: 13px;
+  }
+
+  th {
+    background: #f5f5f5;
+    font-weight: 500;
+  }
+}
+
+.total-rows {
+  margin-top: 8px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.import-result {
+  background: #f8fff8;
+
+  .result-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    color: #388e3c;
+    margin-bottom: 16px;
+  }
+
+  .result-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+
+    div {
+      padding: 12px;
+      background: white;
       border: 1px solid #e0e0e0;
       border-radius: 4px;
-
-      .validation-header {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-weight: 500;
-        margin-bottom: 16px;
-
-        &.valid {
-          color: #388e3c;
-        }
-
-        &.invalid {
-          color: #d32f2f;
-        }
-      }
-
-      h4 {
-        font-size: 14px;
-        font-weight: 500;
-        margin: 16px 0 8px 0;
-      }
-
-      .errors {
-        ul {
-          margin: 0;
-          padding-left: 20px;
-          color: #d32f2f;
-        }
-      }
-
-      .preview-table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-top: 8px;
-
-        th, td {
-          border: 1px solid #e0e0e0;
-          padding: 8px;
-          text-align: left;
-          font-size: 13px;
-        }
-
-        th {
-          background: #f5f5f5;
-          font-weight: 500;
-        }
-      }
-
-      .total-rows {
-        margin-top: 8px;
-        font-size: 13px;
-        color: rgba(0, 0, 0, 0.6);
-      }
+      font-size: 13px;
     }
+  }
 
-    .status-badge {
-      padding: 4px 8px;
-      border-radius: 12px;
-      font-size: 11px;
-      font-weight: 500;
-      text-transform: uppercase;
-
-      &.status-completed {
-        background: #e8f5e9;
-        color: #388e3c;
-      }
-
-      &.status-failed {
-        background: #ffebee;
-        color: #d32f2f;
-      }
-
-      &.status-processing {
-        background: #fff3e0;
-        color: #f57c00;
-      }
+  .result-rows {
+    ul {
+      margin: 0;
+      padding-left: 20px;
     }
+  }
+}
 
-    .no-data {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 48px;
-      color: rgba(0, 0, 0, 0.4);
+.status-badge {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
 
-      mat-icon {
-        font-size: 64px;
-        width: 64px;
-        height: 64px;
-        margin-bottom: 16px;
-      }
-    }
-  
+  &.status-completed {
+    background: #e8f5e9;
+    color: #388e3c;
+  }
+
+  &.status-failed {
+    background: #ffebee;
+    color: #d32f2f;
+  }
+
+  &.status-processing {
+    background: #fff3e0;
+    color: #f57c00;
+  }
+}
+
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px;
+  color: rgba(0, 0, 0, 0.4);
+
+  mat-icon {
+    font-size: 64px;
+    width: 64px;
+    height: 64px;
+    margin-bottom: 16px;
+  }
+}

--- a/frontend/src/app/pages/import/import.component.ts
+++ b/frontend/src/app/pages/import/import.component.ts
@@ -10,10 +10,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { ImportService } from '../../services/import.service';
-import { ImportType, ImportValidation } from '../../core/models';
+import { ImportResultDTO, ImportType, ImportValidation } from '../../core/models';
 
 /**
- * Import page for importing students, teachers, and projects
+ * Import page for importing students and professors from CSV files.
  */
 @Component({
   selector: 'app-import',
@@ -38,11 +38,13 @@ export class ImportComponent {
   private readonly snackBar = inject(MatSnackBar);
 
   ImportType = ImportType;
-  
+
   selectedFile = signal<File | undefined>(undefined);
   validation = signal<ImportValidation | undefined>(undefined);
   importing = signal(false);
   currentImportType = signal<ImportType | undefined>(undefined);
+  importResult = signal<ImportResultDTO | undefined>(undefined);
+  importResultType = signal<ImportType | undefined>(undefined);
 
   downloadTemplate(type: ImportType): void {
     this.importService.downloadTemplate(type);
@@ -54,6 +56,8 @@ export class ImportComponent {
       const file = input.files[0];
       this.selectedFile.set(file);
       this.currentImportType.set(type);
+      this.importResult.set(undefined);
+      this.importResultType.set(undefined);
       this.validateFile(file, type);
 
       // Allow selecting the same file again (browser otherwise may not fire change).
@@ -88,12 +92,18 @@ export class ImportComponent {
 
     this.importService.importCsv(file, type).subscribe({
       next: (result) => {
+        this.importResult.set(result);
+        this.importResultType.set(type);
+        this.selectedFile.set(undefined);
+        this.validation.set(undefined);
+        this.importing.set(false);
+        this.currentImportType.set(undefined);
+
         this.snackBar.open(
           `Import completed! ${result.importedCount}/${result.totalRows} records imported successfully.`,
           'Close',
           { duration: 5000 }
         );
-        this.reset();
       },
       error: (error) => {
         console.error('Import error:', error);
@@ -110,6 +120,7 @@ export class ImportComponent {
     this.validation.set(undefined);
     this.importing.set(false);
     this.currentImportType.set(undefined);
+    this.importResult.set(undefined);
+    this.importResultType.set(undefined);
   }
 }
-


### PR DESCRIPTION
Implemented issue #32.

Changes:
- Integrated the existing CSV import into the admin dashboard.
- Added an import section for students and professors.
- Kept CSV template download functionality.
- Kept CSV file selection, preview and validation.
- Added visible import result output after importing.
- Removed the separate import page from the sidebar menu.
- Reused the existing backend import logic.

Closes #32