### PR TITLE
Add demo data seeding

### DIFF
--- a/backend/WebApplication/WebAPI/Program.cs
+++ b/backend/WebApplication/WebAPI/Program.cs
@@ -9,6 +9,7 @@ using Persistence;
 using Services.Implementations;
 using Services.Interfaces;
 using WebAPI.Endpoints;
+using WebAPI.SeedData;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -102,6 +103,8 @@ using (var scope = app.Services.CreateScope())
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     await db.Database.EnsureCreatedAsync();
 }
+
+await DemoDataSeeder.SeedAsync(app.Services, app.Environment, app.Configuration);
 
 if (app.Environment.IsDevelopment())
 {

--- a/backend/WebApplication/WebAPI/SeedData/2025-11-Tadeot-Assignments.csv
+++ b/backend/WebApplication/WebAPI/SeedData/2025-11-Tadeot-Assignments.csv
@@ -1,0 +1,544 @@
+﻿Abteilung;Klasse;EdufsUsername;Nachname;Vorname;Stop(s);Status
+Elektronik;3AFELA;BG210232;Raštegorac;Luka;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;3AFELA;FE230100;Bečirović;Ermin;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230102;Groza;Raul-Marcos;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230105;Gashi;Ari;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230107;Kabashi;Malsor;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230108;Saliu;Besar;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230110;Mayr;Leonie;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230113;Knögler;Dominik;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230115;Huber;Colin;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230117;Kalyoncuoğlu;Zeyd;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230118;Trbara;Filip;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230119;Zaman;Ayaz;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230121;Alkan;Mirac;Buffet;ACCEPTED
+Elektronik;3AFELA;FE230124;Aumayer;Marcel;Buffet;ACCEPTED
+Elektronik;3AHEL;EL220039;Stadler;Alessandro;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;3AHEL;EL220043;Em;Jan;Kurzpräsentationen HEL/HBG;ACCEPTED
+Elektronik;3AHEL;EL220058;Stef;Darius-Andrei;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;3AHEL;EL220060;Cotescu;David;Let`s do it! (Löt-Workshop);ACCEPTED
+Elektronik;3AHEL;HE230069;Fritz;Simon;Kurzpräsentationen HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230070;Hirth;Felix;;
+Elektronik;3AHEL;HE230074;Garstenauer;Lorenz;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230077;Péterbencze;András;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230080;Lacher;Niklas;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230081;Pilić;Niklas;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230084;Kurt;Sinan;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230086;Bošnjak;Petar;;
+Elektronik;3AHEL;HE230087;Iebed;Mohamed;Let`s do it! (Löt-Workshop);ACCEPTED
+Elektronik;3AHEL;HE230088;Rakušić;Sebastian;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230089;Tran;Domenik;Musikgruppe;ACCEPTED
+Elektronik;3AHEL;HE230093;Dervishaj;Aulon;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230094;Hozanović;Meho;Let`s do it! (Löt-Workshop);ACCEPTED
+Elektronik;3AHEL;HE230095;Dizdarević;Ilhan;Guides HEL/HBG;ACCEPTED
+Elektronik;3AHEL;HE230319;Šandro;Patrik;Guides HEL/HBG;ACCEPTED
+Elektronik;4AFELA;IF200169;Windisch;Jonas;Fachschule;ACCEPTED
+Elektronik;4AFELA;IF210017;Dumitrache;David;Fachschule;ACCEPTED
+Elektronik;4AHEL;EL220040;Elhamedy;Momen;;
+Elektronik;4AHEL;EL220041;Peherstorfer;Melina;Makerweek;ACCEPTED
+Elektronik;4AHEL;EL220042;Stadler;Johannes;Robotik mit Lamborghini Aventador;ACCEPTED
+Elektronik;4AHEL;EL220044;Lehner;Benedikt;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220045;Hutterer;Florian;Zukunft formen: 3D-Druck verbindet Abteilungen;ACCEPTED
+Elektronik;4AHEL;EL220046;Mascherbauer;Julian;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220047;Madlmayr;Christian;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220048;Sierzega;Leo;Robotik mit Lamborghini Aventador;ACCEPTED
+Elektronik;4AHEL;EL220049;Ganglberger;Michael;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;4AHEL;EL220050;Anzinger;Andreas;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220051;Neubauer;Felix;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220054;Aigner;Tim;Zukunft formen: 3D-Druck verbindet Abteilungen;ACCEPTED
+Elektronik;4AHEL;EL220056;Chen;Wang;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;EL220057;Stoiber;Moritz;Robotik mit Lamborghini Aventador;ACCEPTED
+Elektronik;4AHEL;EL220059;Vanev;Hristijan;Robotik mit Lamborghini Aventador;ACCEPTED
+Elektronik;4AHEL;EL220063;Lupic;Hamza;Guides HEL/HBG;ACCEPTED
+Elektronik;4AHEL;HE200246;Žujević;Veljko;;
+Elektronik;4AHEL;HE210289;Lippai;David;Makerweek;ACCEPTED
+Elektronik;4AHEL;HE210295;Stangl;David;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;4AHEL;HE210313;Bodul;Leo;Experimentelle Elektronik/ Hardware und Software;ACCEPTED
+Elektronik;4AHEL;HE210314;Džihanović;Nermin;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE190073;Bichler;Patrik;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE200082;Sadiković;Armin;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE200090;Königslehner;Lucas;Kurzpräsentationen HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE200092;Horn;Dorian;Kurzpräsentationen HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210288;Fortner;Niklas;Best of Projects (EL und MED);ACCEPTED
+Elektronik;5AHEL;HE210293;Neuwirth;Lestat;Experimentelle Elektronik/ Hardware und Software;ACCEPTED
+Elektronik;5AHEL;HE210296;Sommerhuber;Jan;Experimentelle Elektronik/ Hardware und Software;ACCEPTED
+Elektronik;5AHEL;HE210297;Sözdinler;Özlem;Robotik mit Lamborghini Aventador;ACCEPTED
+Elektronik;5AHEL;HE210300;Auberger;Moritz;Best of Projects (EL und MED);ACCEPTED
+Elektronik;5AHEL;HE210301;Ackerbauer;Florian;Vorsicht schnittig (Lasercut);ACCEPTED
+Elektronik;5AHEL;HE210302;Roider;Laurin;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210303;Thaler;Sandro;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210306;Zhelev;Ivo;Best of Projects (EL und MED);ACCEPTED
+Elektronik;5AHEL;HE210308;Djekanović;Slaven;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210309;Sock;Hendrik;Best of Projects (EL und MED);ACCEPTED
+Elektronik;5AHEL;HE210310;Grubeša;Maximilian;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210316;Rakić;Veljko;Guides HEL/HBG;ACCEPTED
+Elektronik;5AHEL;HE210322;Degwerth;Katharina;ShakthiSat Space Team;ACCEPTED
+Informatik;2CHIF;IF240073;Vallant;Fabian;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;IF240076;Kager;Kilian;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;IF240078;Stieger;Jakob;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;IF240081;Nagy;Christian;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;﻿IF240084;Auer;Lukas;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;IF240085;Högl;Jonathan;DDP (Design of Digital Products);ACCEPTED
+Informatik;2CHIF;IF240164;Harnúšek;Markus;Künstliche Intelligenz;ACCEPTED
+Informatik;2IHIF;IF240040;Topić;Angela;Guides CSI;ACCEPTED
+Informatik;2IHIF;IF240042;Reder;Valentina;Guides CSI;ACCEPTED
+Informatik;2IHIF;IF240058;Pavel;Ianis;Guides CSI;ACCEPTED
+Informatik;3AHIF;IF210025;Arifi;Lind;Buffet;ACCEPTED
+Informatik;3AHIF;IF210033;Dimeski;Alberto;Buffet;ACCEPTED
+Informatik;3AHIF;IF210078;Özdemir;Kezban;Empfang;ACCEPTED
+Informatik;3AHIF;IF220135;Tran;Duong;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF220141;Mehrabyan;Hamlet;Buffet;ACCEPTED
+Informatik;3AHIF;IF220181;Haj Najib;Osama;Buffet;ACCEPTED
+Informatik;3AHIF;IF230131;Nelson;Sarah;Guides HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230135;Dobersberger;Sarah;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230138;Pressl;Zoe;Buffet;ACCEPTED
+Informatik;3AHIF;IF230139;Mayer;Elena;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230144;Tuholjaković;Aldin;Empfang;ACCEPTED
+Informatik;3AHIF;IF230146;Katzlberger;Franziska;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230149;Pauker;Matea;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230151;Hörmedinger;Julia;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230153;Neuhauser;Annika;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230160;Zannantoni;Felix;Infrastruktur;ACCEPTED
+Informatik;3AHIF;IF230161;Purcaru;David-Constantin;Empfang;ACCEPTED
+Informatik;3AHIF;IF230163;Gül;Lena;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230164;Schwingenschuh;Sebastian;Infrastruktur;ACCEPTED
+Informatik;3AHIF;IF230167;Ehrenmüller-Jensen;Victor;Infrastruktur;ACCEPTED
+Informatik;3AHIF;IF230168;Einzinger;Julian;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230169;Baumann;Sonja;Wirtschaft;ACCEPTED
+Informatik;3AHIF;IF230171;Stolz;Paul;Buffet;ACCEPTED
+Informatik;3AHIF;IF230172;Egger;Adrian;Empfang;ACCEPTED
+Informatik;3AHIF;IF230173;Schwabegger;Lukas;Empfang;ACCEPTED
+Informatik;3AHIF;IF230174;Simunović;Petra;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230176;Gül;Hanna;Schnupperprogrammieren;ACCEPTED
+Informatik;3AHIF;IF230177;Rothbauer;Raphael;Empfang;ACCEPTED
+Informatik;3AHIF;IF230184;Adilović;Sulejman;Empfang;ACCEPTED
+Informatik;3AHIF;IF230186;Folger;Konstantin;Empfang;ACCEPTED
+Informatik;3AHIF;IF230187;Springer;Penelope;Musikgruppe;ACCEPTED
+Informatik;3AHIF;IF230188;Kanmaz;Metehan;Guides HIF/HITM;ACCEPTED
+Informatik;3AHIF;IF230318;Amza;Elida;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF210003;Ibo;Lawand;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF220116;Dönmez;Arda;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF220117;Heissinger;Julian;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF220148;Kurtić;Edin;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF220157;Stoica;Benjamin;Schnupperprogrammieren;ACCEPTED
+Informatik;3BHIF;IF220184;Gashi;Rron;Buffet;ACCEPTED
+Informatik;3BHIF;IF220188;Marić;Luka;Schnupperprogrammieren;ACCEPTED
+Informatik;3BHIF;IF220195;James;Ryan;Buffet;ACCEPTED
+Informatik;3BHIF;IF230061;Trkulja;Marko;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230127;Musić;Ernad;Schnupperprogrammieren;ACCEPTED
+Informatik;3BHIF;IF230130;Satybaldy-Ulu;Danijar;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230133;Lohninger;Paul;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF230134;Mostbauer;Julian;Schnupperprogrammieren;ACCEPTED
+Informatik;3BHIF;IF230140;Becer;Deniz;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF230142;Hadžić;Almir;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF230145;Hassani;Koorosh;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230147;Grünzweil;Lukas;Humanoid Robotics;ACCEPTED
+Informatik;3BHIF;IF230152;Dirnberger;Arthur;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230155;Hasem;Ali;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230156;Yağci;Kerimcan;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230158;Elgit;Samed;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF230159;Brunner;Jan;Schnupperprogrammieren;ACCEPTED
+Informatik;3BHIF;IF230162;Solomun;Mario;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230165;Parzer;Lorenz;Infrastruktur;ACCEPTED
+Informatik;3BHIF;IF230175;Darabos;Mátyás;Humanoid Robotics;ACCEPTED
+Informatik;3BHIF;IF230179;Reitbauer;Erik;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230180;Mamsaleh;Daryan;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230182;Marazović;Leon;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230183;Haider;Nico;Guides HIF/HITM;ACCEPTED
+Informatik;3BHIF;IF230185;Dürk;Fridolin;Guides HIF/HITM;ACCEPTED
+Informatik;3IHIF;IF230034;Brindl;Timon;Guides CSI;ACCEPTED
+Informatik;3IHIF;IF230040;Tripathi;Aniket;Virtual Reality & Gaming;ACCEPTED
+Informatik;3IHIF;IF230041;Frühwirt;David;Infrastruktur;ACCEPTED
+Informatik;3IHIF;IF230042;González Vivar;Jazmin del Carmen;Wirtschaft;ACCEPTED
+Informatik;3IHIF;IF230043;Mukhin;Oleksandr;Wirtschaft;ACCEPTED
+Informatik;3IHIF;IF230047;Pühringer;Laurenz;Wirtschaft;ACCEPTED
+Informatik;3IHIF;IF230048;Polimac;Kristian;Guides CSI;ACCEPTED
+Informatik;3IHIF;IF230050;Abdulwahid;Mohamad;Humanoid Robotics;ACCEPTED
+Informatik;3IHIF;IF230051;Zwettler;David;Infrastruktur;ACCEPTED
+Informatik;3IHIF;IF230052;Hinterleitner;Moritz;Infrastruktur;ACCEPTED
+Informatik;3IHIF;IF230053;Tismonar;Marc;Infrastruktur;ACCEPTED
+Informatik;3IHIF;IF230056;Malanyak;Ostap;Wirtschaft;ACCEPTED
+Informatik;3IHIF;IF230058;Wimmer;Audrey;Guides CSI;ACCEPTED
+Informatik;3IHIF;IF230062;Chhantyal;Nishan;Humanoid Robotics;ACCEPTED
+Informatik;3IHIF;IF230066;Petrov;Antonio;Virtual Reality & Gaming;ACCEPTED
+Informatik;3IHIF;IF230129;Pernkopf;Viktoria;Guides CSI;ACCEPTED
+Informatik;3IHIF;IF230317;Elyasi;Behrang;Guides CSI;ACCEPTED
+Informatik;3IHIF;IF230320;Shashkin;Ilia;Infrastruktur;ACCEPTED
+Informatik;3IHIF;IF230325;Ayan;Muhammad;Humanoid Robotics;ACCEPTED
+Informatik;4AHIF;FE210335;Gugerbauer;Clemens;Künstliche Intelligenz;ACCEPTED
+Informatik;4AHIF;IF210035;Mbala;Matanu;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF210047;Stummer;Jan;Guides HIF/HITM;ACCEPTED
+Informatik;4AHIF;IF210080;Musić;Lejla;Empfang;ACCEPTED
+Informatik;4AHIF;IF210124;Wetscher;Konstantin;Infrastruktur;ACCEPTED
+Informatik;4AHIF;IF210129;Ngimbi;Sarah;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220091;Graßauer;Lena;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF220095;Feichtinger;Leona;Künstliche Intelligenz;ACCEPTED
+Informatik;4AHIF;IF220096;Subašić;Antonio;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220100;Koller;Simon;Infrastruktur;ACCEPTED
+Informatik;4AHIF;IF220104;Wildberger;André;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220105;Becker;Samuel;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF220115;Larndorfer;Lukas;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220119;Grünzweil;Mark;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220124;Findenig;Leonie;Künstliche Intelligenz;ACCEPTED
+Informatik;4AHIF;IF220126;Wohlschlager;Florian;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220133;Schneiderbauer;Sebastian;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220140;Wildberger;Luca;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220146;Piskernik;Lorenz;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF220147;Ladstätter;Henry;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;4AHIF;IF220152;Vrhovac;David;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF220162;Dallinger;Flora;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF220179;Ciğer;Deniz;Künstliche Intelligenz;ACCEPTED
+Informatik;4AHIF;IF220183;Bauer;Melanie;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;4AHIF;IF220192;Weißl-Fischer;David;Infrastruktur;ACCEPTED
+Informatik;4AHIF;IF220194;Silnović;Almina;Empfang;ACCEPTED
+Informatik;4AHIF;IF220197;Einzenberger;Katharina;Virtual Reality & Gaming;ACCEPTED
+Informatik;4AHIF;IF220201;Horvath;Fabian;Smart Cyber Systems;ACCEPTED
+Informatik;4AHIF;IF250302;Kis;Emily;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF210044;Moser;Jonas;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF210100;Raab;Philip;Infrastruktur;ACCEPTED
+Informatik;4BHIF;IF210114;Jašić;Alin;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF210122;Mezildžić;Danis;Buffet;ACCEPTED
+Informatik;4BHIF;IF210139;Yüzüak;Semih;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220093;Mayrhofer;Julian;Smart Cyber Systems;ACCEPTED
+Informatik;4BHIF;IF220102;Ruis;Jakob;Buffet;ACCEPTED
+Informatik;4BHIF;IF220107;Mayrwöger;Jacob;Smart Cyber Systems;ACCEPTED
+Informatik;4BHIF;IF220108;Schneeberger;Philipp;Buffet;ACCEPTED
+Informatik;4BHIF;IF220110;Kahlhofer;Fabian;Wirtschaft;ACCEPTED
+Informatik;4BHIF;IF220113;Haludek;David;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220120;Coroi;Alexander;Infrastruktur;ACCEPTED
+Informatik;4BHIF;IF220122;Preining;Kylian;Wirtschaft;ACCEPTED
+Informatik;4BHIF;IF220127;Neumayer;Maximilian;Smart Cyber Systems;ACCEPTED
+Informatik;4BHIF;IF220128;Kaindl;Alexander;Buffet;ACCEPTED
+Informatik;4BHIF;IF220142;Zauner;Erik;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220145;Froschauer;Kilian;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220150;Baysoy;Rabbi;Infrastruktur;ACCEPTED
+Informatik;4BHIF;IF220154;Al Desoky;Omar;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220158;Matulin;Simon;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220163;Kuwilsky;Levi;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220165;Eichinger;Richard;Smart Cyber Systems;ACCEPTED
+Informatik;4BHIF;IF220167;Pichler;Adrian;Buffet;ACCEPTED
+Informatik;4BHIF;IF220172;Jahoda;Maximilian;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220177;Topolanek;Laurin;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220180;Königstorfer;Christian;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220185;Nuždić;Milan;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220186;Kaleškov;Filip;Guides HIF/HITM;ACCEPTED
+Informatik;4BHIF;IF220189;Bamberger;Florian;Wirtschaft;ACCEPTED
+Informatik;4CHIF;IF210068;Fornvald;Roland;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF210083;Bramel;Nico;Mathematik anwenden und begreifen;ACCEPTED
+Informatik;4CHIF;IF210096;Iancu;Eduard-Andrei;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220090;Zeko;Dorijan;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220092;Naderer;David;Humanoid Robotics;ACCEPTED
+Informatik;4CHIF;IF220094;Bjelobrk;Victor;Mathematik anwenden und begreifen;ACCEPTED
+Informatik;4CHIF;IF220098;Federsel;Vincent;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220101;Bintinger;Nico;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220103;Harrer;Valentin;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220106;Schweighardt;Pascal;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220109;Hinterdorfer;Jonas;Humanoid Robotics;ACCEPTED
+Informatik;4CHIF;IF220125;Klemm;Alexander;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220129;Nedić;Andrej;Mathematik anwenden und begreifen;ACCEPTED
+Informatik;4CHIF;IF220149;Džaferović;Amar;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220160;Panwinkler;Martin;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220164;Gerstmayr;Paul;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220166;Krippel;Florian;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220168;Stadlmair;Christoph;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220169;Langeder;David;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220170;Wögerbauer;Simon;Humanoid Robotics;ACCEPTED
+Informatik;4CHIF;IF220171;Schwendtbauer;Julian;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220176;Mörtendorfer;Lukas;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220178;Oswald;Michael;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220182;Bindreiter;Moritz;Mathematik anwenden und begreifen;ACCEPTED
+Informatik;4CHIF;IF220190;Li;Keyu;Best of Projects (INF+MDT);ACCEPTED
+Informatik;4CHIF;IF220193;Mátyás;Zsombor;Smart Cyber Systems;ACCEPTED
+Informatik;4CHIF;IF220196;Dollhäubl;Arian;Roboterführerschein;ACCEPTED
+Informatik;4CHIF;IF220199;Groß;Manuel;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5AHIF;IF210009;Gastelsberger;Lucas;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;5AHIF;IF210014;Haas;Luca;Künstliche Intelligenz;ACCEPTED
+Informatik;5AHIF;IF210015;Hornhuber;Caroline;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5AHIF;IF210019;Keplinger;Erik;Guides HIF/HITM;ACCEPTED
+Informatik;5AHIF;IF210022;Kirchmayr;Daniel;Infrastruktur;ACCEPTED
+Informatik;5AHIF;IF210029;Dohr;Melanie;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5AHIF;IF210040;Al Shoufi;Yane;Mathematik anwenden und begreifen;ACCEPTED
+Informatik;5AHIF;IF210041;Breneis;Leo;Künstliche Intelligenz;ACCEPTED
+Informatik;5AHIF;IF210042;Hathaler;Michael;Guides HIF/HITM;ACCEPTED
+Informatik;5AHIF;IF210048;Huber;Andreas;Künstliche Intelligenz;ACCEPTED
+Informatik;5AHIF;IF210052;Klein;Eros;Künstliche Intelligenz;ACCEPTED
+Informatik;5AHIF;IF210058;Tomas;Damjan;Infrastruktur;ACCEPTED
+Informatik;5AHIF;IF210059;Novaković;Filip;Empfang;ACCEPTED
+Informatik;5AHIF;IF210061;Kohlböck;Felix;Empfang;ACCEPTED
+Informatik;5AHIF;IF210065;Bernhofer;Moritz;Künstliche Intelligenz;ACCEPTED
+Informatik;5AHIF;IF210072;Vieghofer;Tobias;Guides HIF/HITM;ACCEPTED
+Informatik;5AHIF;IF210079;Preinfalk;Marco;Guides HIF/HITM;ACCEPTED
+Informatik;5AHIF;IF210132;Oberndorfer;Leo;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5AHIF;IT210173;Minihuber;Konstantin;Infrastruktur;ACCEPTED
+Informatik;5BHIF;IF190106;Ignac;Antonio;Guides HIF/HITM;ACCEPTED
+Informatik;5BHIF;IF200137;Kurtic;Ademir;Guides HIF/HITM;ACCEPTED
+Informatik;5BHIF;IF200200;Stroschneider;Fabian;Künstliche Intelligenz;ACCEPTED
+Informatik;5BHIF;IF210001;Hasenschwandtner;Andreas;Empfang;ACCEPTED
+Informatik;5BHIF;IF210005;Katsanis;Jannis;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210010;Höllerl;Adam;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210011;Wilflingseder;Benjamin;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5BHIF;IF210018;Tea;Vincent;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210024;Resch;Alexander;Künstliche Intelligenz;ACCEPTED
+Informatik;5BHIF;IF210028;Schwab;David;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5BHIF;IF210037;Richter;Tobias;Empfang;ACCEPTED
+Informatik;5BHIF;IF210046;Mifka;René;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210053;Perger;Lukas;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210062;Bergmann;Max;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5BHIF;IF210063;Achleitner;Paul;Empfang;ACCEPTED
+Informatik;5BHIF;IF210084;Schein;Paul;Virtual Reality & Gaming;ACCEPTED
+Informatik;5BHIF;IF210091;Passenbrunner;Moritz;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5BHIF;IF210099;Hagleitner;Manuel;Künstliche Intelligenz;ACCEPTED
+Informatik;5BHIF;IF210104;Berg;Bajtur;Künstliche Intelligenz;ACCEPTED
+Informatik;5BHIF;IF210105;Borza;Mihai;Roboterführerschein;ACCEPTED
+Informatik;5BHIF;IF210106;Batbold;Tsolmonbat;Künstliche Intelligenz;ACCEPTED
+Informatik;5BHIF;IF210130;Lambourne-Grüneis;Elija;Künstliche Intelligenz;ACCEPTED
+Informatik;5CHIF;HE200101;Ignjatović;Luka;Infrastruktur;ACCEPTED
+Informatik;5CHIF;IF200103;Mushtaq;Obaidullah;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF200114;Ademi;Zinedin;Infrastruktur;ACCEPTED
+Informatik;5CHIF;IF200121;Csomány;Axel;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF200129;Avdic;Emil;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF200166;Htet Htun;Kyaw;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF200190;Bjelak;Denis;Infrastruktur;ACCEPTED
+Informatik;5CHIF;IF210006;Mistelberger;Leopold;Guides HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF210007;Mohamadi;Amirhossein;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF210013;Kletsch;Tobias;Infrastruktur;ACCEPTED
+Informatik;5CHIF;IF210026;Silber;Emil;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF210027;Mahr;Elias;Empfang;ACCEPTED
+Informatik;5CHIF;IF210050;Schauer;Filip;Kurzpräsentationen HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF210057;Schörgendorfer;Luis;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5CHIF;IF210064;Radić;Sebastian;Best of Projects (INF+MDT);ACCEPTED
+Informatik;5CHIF;IF210069;Schreiegg;Aaron;Guides HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF210074;Pešut;Simon;Guides HIF/HITM;ACCEPTED
+Informatik;5CHIF;IF210088;Guran;Vlad-Raul;Empfang;ACCEPTED
+Informatik;5CHIF;IF210089;Jelić;Stefan;Empfang;ACCEPTED
+Informatik;5CHIF;IF210102;Birklbauer;Michael;Empfang;ACCEPTED
+Informatik;5CHIF;IF210103;Mladenović;Nikola;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF210109;Moradi;Milad;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF210117;Cristea;David-Boaz;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF210123;Schmalzer;Timon;Empfang;ACCEPTED
+Informatik;5CHIF;IF210127;Brunner;Moritz;Humanoid Robotics;ACCEPTED
+Informatik;5CHIF;IF210133;Zehetner;Leon;Empfang;ACCEPTED
+Medientechnik;2AHITM;﻿IT230193;Eser;Finn;;
+Medientechnik;2AHITM;IT240236;Midžić;Adyan;Social Media Team;ACCEPTED
+Medientechnik;2BHITM;IT240216;Pal;Jannis;Podcasts - Schwammerltalk;ACCEPTED
+Medientechnik;2BHITM;IT240223;Schumacher;Armin;Podcasts - Schwammerltalk;ACCEPTED
+Medientechnik;2BHITM;IT240226;Velić;Maid;Podcasts - Schwammerltalk;ACCEPTED
+Medientechnik;3AHITM;IF210055;Ungerhofer;Julian;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3AHITM;IT210186;Velić;Amir;Infrastruktur;ACCEPTED
+Medientechnik;3AHITM;IT220207;Schachner;Daniel;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3AHITM;IT220245;Posch;Tobias;Video- & Foto-Garden;ACCEPTED
+Medientechnik;3AHITM;IT230199;Reder;Juliana;Web Garden;ACCEPTED
+Medientechnik;3AHITM;IT230202;Hofer;Simon;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230209;Hartmann;Emily;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;3AHITM;IT230214;Krenglmüller;Clemens;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230215;Lehner;Nicolas;Infrastruktur;ACCEPTED
+Medientechnik;3AHITM;IT230228;Ebner;Moritz;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230233;Klug;Noah;Infrastruktur;ACCEPTED
+Medientechnik;3AHITM;IT230238;Klaffenböck;Eva;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230241;Auinger;Jan;Buffet;ACCEPTED
+Medientechnik;3AHITM;IT230243;Ferschmann;Maximilian;Buffet;ACCEPTED
+Medientechnik;3AHITM;IT230244;Kempl;Sophie;Web Garden;ACCEPTED
+Medientechnik;3AHITM;IT230245;Hutegger;Armin;Infrastruktur;ACCEPTED
+Medientechnik;3AHITM;IT230252;Goller;Katharina;Web Garden;ACCEPTED
+Medientechnik;3AHITM;IT230255;See;Annalena;Web Garden;ACCEPTED
+Medientechnik;3AHITM;IT230256;Kemmer;Manuel;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230257;Wagner;Adrian;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3AHITM;IT230261;Grugl;Theodor;Streaming- und Regieraum;ACCEPTED
+Medientechnik;3AHITM;IT230265;Scheuringer;Michael;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3AHITM;IT230270;Kranebitter;Nico;Musikgruppe;ACCEPTED
+Medientechnik;3AHITM;IT230322;Huskić-Šantić;Benjamin;Buffet;ACCEPTED
+Medientechnik;3BHITM;IF200126;Mc Neall;Laurent;Smart Cyber Systems;ACCEPTED
+Medientechnik;3BHITM;IT220212;Straßer;Julian;Medientechnik Cinema;ACCEPTED
+Medientechnik;3BHITM;IT220226;Lipták;Tamás;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3BHITM;IT220279;Focke;Bernhard;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;3BHITM;IT230190;Neumüller;Christoph;Medientechnik Cinema;ACCEPTED
+Medientechnik;3BHITM;IT230197;Farfeleder;Samuel;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230205;Payreder;Tobias;Guides HIF/HITM;ACCEPTED
+Medientechnik;3BHITM;IT230221;Schütz;Matthias;Guides HIF/HITM;ACCEPTED
+Medientechnik;3BHITM;IT230222;Hölzl;Tobias;Guides HIF/HITM;ACCEPTED
+Medientechnik;3BHITM;IT230225;Benea;Lukas-Michael;Medientechnik Cinema;ACCEPTED
+Medientechnik;3BHITM;IT230226;Vokal;Thomas;Buffet;ACCEPTED
+Medientechnik;3BHITM;IT230229;Altrichter;Clemens;Gaming Garden;ACCEPTED
+Medientechnik;3BHITM;IT230231;Ebner;Luca;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230240;Lacle;Salvator;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230242;Pühringer;Clemens;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230247;Freund;Felix;Gaming Garden;ACCEPTED
+Medientechnik;3BHITM;IT230248;Köhrer;Raphael;Buffet;ACCEPTED
+Medientechnik;3BHITM;IT230249;Warlischek;Julian;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230250;Lachner;David;Smart Cyber Systems;ACCEPTED
+Medientechnik;3BHITM;IT230253;Auinger;Manuel;Guides HIF/HITM;ACCEPTED
+Medientechnik;3BHITM;IT230254;Starchl-Barbu;Daniel;Social Media Team;ACCEPTED
+Medientechnik;3BHITM;IT230262;Muzaferović;Adnan;Gaming Garden;ACCEPTED
+Medientechnik;3BHITM;IT230263;Bauer;Roland;Social Media Team;ACCEPTED
+Medientechnik;3BHITM;IT230266;Rammerstorfer;Martin;Smart Cyber Systems;ACCEPTED
+Medientechnik;3BHITM;IT230268;Eder;Mark;Web Garden;ACCEPTED
+Medientechnik;3BHITM;IT230271;Graski;Lukas;Buffet;ACCEPTED
+Medientechnik;4AHITM;IT210180;Mahmutović;Almin;Guides HIF/HITM;ACCEPTED
+Medientechnik;4AHITM;IT210188;Winklbauer;Marlies;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT210200;Schachner;Stefan;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220211;Radpolt;Daniel;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220215;Geigenberger;Gregor;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220220;Beganović;Eldin;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220223;Pointinger;Elias;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220224;Lettner;Daniel;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220230;Mehić;Hanan;Guides HIF/HITM;ACCEPTED
+Medientechnik;4AHITM;IT220231;Zangenfeind;Clemens;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220234;Eder;Simon;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220241;Gnadlinger;Miriam;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220259;Leitner;Jonas;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220266;Huemer-Fistelberger;Jakob;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220270;Windischbauer;David;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220281;Kreinecker;Paul;Informatik-Experimente;ACCEPTED
+Medientechnik;4AHITM;IT220285;Sperrer;Simone;Informatik-Experimente;ACCEPTED
+Medientechnik;4BHITM;IT200233;Satzinger;Niklas;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;4BHITM;IT200245;Mahringer;Daniel;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;4BHITM;IT210143;Stelzmüller;Michael;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT210151;Wanson;Björn;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT210152;Binder;Dominik;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT220209;Bergmair;Erik;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT220214;Dimmler;Carla;Social Media Team;ACCEPTED
+Medientechnik;4BHITM;IT220218;Vejmelek;Viktoria;Social Media Team;ACCEPTED
+Medientechnik;4BHITM;IT220221;Meinhart;Stefan;Video- & Foto-Garden;ACCEPTED
+Medientechnik;4BHITM;IT220228;Riemer;Daniel;Buffet;ACCEPTED
+Medientechnik;4BHITM;IT220229;Richter;Julian;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT220235;Reder;Anna;Social Media Team;ACCEPTED
+Medientechnik;4BHITM;IT220240;Rieser;Niilo;Guides HIF/HITM;ACCEPTED
+Medientechnik;4BHITM;IT220252;Hochhuber;Tanja;Video- & Foto-Garden;ACCEPTED
+Medientechnik;4BHITM;IT220253;Auer;Joschua;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT220257;Lehner;Sebastian;Infrastruktur;ACCEPTED
+Medientechnik;4BHITM;IT220263;Hörtenhuber;Simeon;Gaming Garden;ACCEPTED
+Medientechnik;4BHITM;IT220265;Joos;Fabian;Guides HIF/HITM;ACCEPTED
+Medientechnik;4BHITM;IT220269;Berghahn;David;Guides HIF/HITM;ACCEPTED
+Medientechnik;4BHITM;IT220272;Tesar;Nino;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;4BHITM;IT220274;Briefeneder;Martin;Buffet;ACCEPTED
+Medientechnik;4CHITM;IT220204;Neundlinger;Fabio;Medientechnik Cinema;ACCEPTED
+Medientechnik;4CHITM;IT220205;Vahram;Chris;Guides HIF/HITM;ACCEPTED
+Medientechnik;4CHITM;IT220208;Bernecker;Deniz;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220210;Huber;Florian;Video- & Foto-Garden;ACCEPTED
+Medientechnik;4CHITM;IT220213;Kapeller;Moritz;Streaming- und Regieraum;ACCEPTED
+Medientechnik;4CHITM;IT220216;Cinac;Sean;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220219;Preslmair;Luca;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220222;Lehner;Benedikt;Medientechnik Cinema;ACCEPTED
+Medientechnik;4CHITM;IT220225;Hofer;Nico;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220233;Preslmair;Marc;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220236;Huemer;Tobias;Video- & Foto-Garden;ACCEPTED
+Medientechnik;4CHITM;IT220238;Freihaut;Manuel;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;4CHITM;IT220242;Dokter;Simon;Medientechnik Cinema;ACCEPTED
+Medientechnik;4CHITM;IT220256;Mišić;Andreja;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220258;Leumüller;Alessandro;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220260;Schiffler;Julian;Guides HIF/HITM;ACCEPTED
+Medientechnik;4CHITM;IT220268;Stögermüller;Maximilian;Guides HIF/HITM;ACCEPTED
+Medientechnik;4CHITM;IT220271;Peneder;Jakob;Medientechnik Cinema;ACCEPTED
+Medientechnik;4CHITM;IT220273;Forster;Julian;Gaming Garden;ACCEPTED
+Medientechnik;4CHITM;IT220276;Rotariu;Richard;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;5AHITM;IT190208;Scharrer;Raphael;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT200227;Bauer;Alina;Guides HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT200244;Reisinger;Raphael;Guides HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT200299;Erkol;Yasin;Infrastruktur;ACCEPTED
+Medientechnik;5AHITM;IT210140;Spöck;Lilith;Gaming Garden;ACCEPTED
+Medientechnik;5AHITM;IT210141;Grad;Kinga;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5AHITM;IT210142;Gossenreiter;Thomas;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210146;Pramhas;Laurent;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5AHITM;IT210153;Korzeniowski;Christoph;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210157;Pfarrhofer;Philip;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;5AHITM;IT210158;Lehner;Sophia;Medientechnik Cinema;ACCEPTED
+Medientechnik;5AHITM;IT210161;Graf;Pia;Guides HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210164;Pabst;Gabriel;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5AHITM;IT210166;Steinmair;Stefanie;Schnupperprogrammieren;ACCEPTED
+Medientechnik;5AHITM;IT210168;Ćufurović;Abdulkerim;Guides HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210169;Murach;Julian;Guides HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210170;Tran;Markus;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210174;Hochbichler;Lien;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210181;Baumann;Isabella;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210182;Hahn;Alexander;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;5AHITM;IT210193;Klement;Tobias;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5AHITM;IT210195;Rosenbichler;Timon;Gaming Garden;ACCEPTED
+Medientechnik;5BHITM;IT200230;Anderson;Marvin;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5BHITM;IT200235;Brandstätter;Elias;Guides HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT200238;Hayer;Florian;Virtual Reality & Gaming;ACCEPTED
+Medientechnik;5BHITM;IT200258;Michel;Jakob;Guides HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT210137;Kaltenberger;Elisa;Virtual Reality & Gaming;ACCEPTED
+Medientechnik;5BHITM;IT210155;Schönbauer;Linnea;Virtual Reality & Gaming;ACCEPTED
+Medientechnik;5BHITM;IT210159;Huch;Tobias;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5BHITM;IT210160;Ćatić;Vanesa;Künstliche Intelligenz;ACCEPTED
+Medientechnik;5BHITM;IT210175;Stützner;Michael;Gaming Garden;ACCEPTED
+Medientechnik;5BHITM;IT210176;Klaffenböck;Jakob;Guides HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT210178;Wizany;Linus;Guides HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT210179;Öller;Konstantin;Kurzpräsentationen HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT210184;Kreuzer;Andreas;Ton-Studio / Video-Studio;ACCEPTED
+Medientechnik;5BHITM;IT210185;Şimşek;Atilla;Guides HIF/HITM;ACCEPTED
+Medientechnik;5BHITM;IT210190;Zinhobel;Luca;Gaming Garden;ACCEPTED
+Medientechnik;5BHITM;IT210192;Mayer;Samuel;Best of Projects (INF+MDT);ACCEPTED
+Medientechnik;5BHITM;IT210196;Mayr;Tim;Künstliche Intelligenz;ACCEPTED
+Medientechnik;5BHITM;IT220334;Öllinger;Zoe;Künstliche Intelligenz;ACCEPTED
+Medizintechnik;3AHBG;BG210229;Khasho;Vin;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG220023;Neumann;Jürgen;Vorsicht schnittig (Lasercut);ACCEPTED
+Medizintechnik;3AHBG;BG230001;Sigmund;Max;;
+Medizintechnik;3AHBG;BG230002;Benedek;Luca;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230003;Hinterreiter;Moritz;Vorsicht schnittig (Lasercut);ACCEPTED
+Medizintechnik;3AHBG;BG230006;Wimmer;Rebecca;Check Your Health / Biomedizin-Labor;ACCEPTED
+Medizintechnik;3AHBG;BG230007;Perner;Damaris;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;3AHBG;BG230008;Schütz;Paula;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230009;Floh;Leonie;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230011;Scalet;Livia;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;3AHBG;BG230012;Rahmani;Najla;;
+Medizintechnik;3AHBG;BG230015;Luketina;Klara;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230019;Pejić;Lana;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230020;Ginzinger;Philipp;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230021;Miković;Sofija;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230022;Frim;Sarah;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230023;Hintersteiner;Lea;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230026;Miesenberger;Valentin;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230027;Drljača;Andjela;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230028;Subić;Teodora;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230029;Steinwendner;Sophia;Check Your Health / Biomedizin-Labor;ACCEPTED
+Medizintechnik;3AHBG;BG230030;Grether;Maximilian;Guides HEL/HBG;ACCEPTED
+Medizintechnik;3AHBG;BG230073;Maros;Niko;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG210203;Seifert;Philipp;Check Your Health / Biomedizin-Labor;ACCEPTED
+Medizintechnik;4AHBG;BG210209;Letić;Leyla;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG210218;Zukić;Amina;Guides HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG210221;Füreder;Lukas;Experimentelle Elektronik/ Hardware und Software;ACCEPTED
+Medizintechnik;4AHBG;BG210228;Sideras;Stefanos;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220001;Paireder;Lana;;
+Medizintechnik;4AHBG;BG220002;Froschauer;Elias;Guides HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG220003;Kugler;Elisabeth;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;4AHBG;BG220004;Kizić;Sergej;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220005;Muheljić;Adelina;Guides HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG220006;Dyab;Ghaith;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220007;Wagner;Paul;Check Your Health / Biomedizin-Labor;ACCEPTED
+Medizintechnik;4AHBG;BG220008;Hoffmann;Manuel;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220010;Klaffenböck;Moritz;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG220011;Pasztor;Anita;;
+Medizintechnik;4AHBG;BG220013;Rekić;Lejla;Buffet;ACCEPTED
+Medizintechnik;4AHBG;BG220014;Ennsbrunner;Carina;;
+Medizintechnik;4AHBG;BG220017;Burzić;Mineta;Buffet;ACCEPTED
+Medizintechnik;4AHBG;BG220018;Pfeiffer;Jonas;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220019;Größlinger;Theresa;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;4AHBG;BG220020;Steinmaurer;Philipp;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220024;Brandl;Sophia;Guides HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG220030;Joham;Sigrun;;
+Medizintechnik;4AHBG;BG220031;Hrustić;Salim;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220032;Höller;Jonathan;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG220033;Fehleisen;Christoph;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220034;Detter;Raphael;Makerweek;ACCEPTED
+Medizintechnik;4AHBG;BG220037;Shafeeva;Amaliya;Guides HEL/HBG;ACCEPTED
+Medizintechnik;4AHBG;BG240032;Zec;Ignyat;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;5AHBG;BG200051;Duraku;Florian;Guides HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG200053;Belko;Sanih;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG200066;Eder;Gwendolin;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210204;Schaumberger;Helene;ShakthiSat Space Team;ACCEPTED
+Medizintechnik;5AHBG;BG210206;Springer;David;Best of Projects (EL und MED);ACCEPTED
+Medizintechnik;5AHBG;BG210207;Rohrauer;Stella;Best of Projects (EL und MED);ACCEPTED
+Medizintechnik;5AHBG;BG210208;Schuhmayer;Rafael;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210213;Weinbergmaier;Raphael;Best of Projects (EL und MED);ACCEPTED
+Medizintechnik;5AHBG;BG210214;Hack;Elena;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210215;Knežević;Sandra;Guides HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210216;Schallaböck;Katharina;ShakthiSat Space Team;ACCEPTED
+Medizintechnik;5AHBG;BG210219;Pumberger;Alexander;Best of Projects (EL und MED);ACCEPTED
+Medizintechnik;5AHBG;BG210224;Frim;Paul;Guides HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210226;Manzenreiter;Paulina;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210227;Oberngruber;Nina;Kurzpräsentationen HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210238;Leeb;Charlotte;Guides HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210242;Schall;Karoline;Guides HEL/HBG;ACCEPTED
+Medizintechnik;5AHBG;BG210245;Pilić;Gabriel;Medizintechnik / Ultraschall / EKG;ACCEPTED
+Medizintechnik;5AHBG;BG210247;Bauer;Annelie;Kurzpräsentationen HEL/HBG;ACCEPTED

--- a/backend/WebApplication/WebAPI/SeedData/DemoDataSeeder.cs
+++ b/backend/WebApplication/WebAPI/SeedData/DemoDataSeeder.cs
@@ -1,0 +1,568 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+using Persistence.Entities;
+
+namespace WebAPI.SeedData;
+
+public static class DemoDataSeeder
+{
+    private const string CurrentSchoolYear = "2025/26";
+    private static readonly string[] SchoolYears = ["2023/24", "2024/25", CurrentSchoolYear];
+    private static readonly string CsvFileName = Path.Combine("SeedData", "2025-11-Tadeot-Assignments.csv");
+
+    private static readonly DemoProfessor[] DemoProfessors =
+    [
+        new("bschroedt", "Barbara", "Schrödt"),
+        new("dmayer", "Daniel", "Mayer"),
+        new("mhofer", "Martin", "Hofer"),
+        new("skern", "Sabine", "Kern"),
+        new("tleitner", "Thomas", "Leitner"),
+        new("jberger", "Julia", "Berger"),
+        new("cgruber", "Christoph", "Gruber"),
+        new("awagner", "Anna", "Wagner")
+    ];
+
+    private static readonly DemoProject[] DemoProjects =
+    [
+        new("HTL Project Management Platform", "Webplattform zur Verwaltung von SYP-Projekten, Teammitgliedern, Betreuern und Projektstatus.", "C#, ASP.NET Core, Angular, PostgreSQL", ProjectStatus.OnGoing, ProjectType.SYP, CurrentSchoolYear),
+        new("Tage der offenen Tür Guide App", "Mobile Web-App mit Stationen, Raumplan, Live-Informationen und Feedback für Besucherinnen und Besucher.", "Angular, TypeScript, REST API", ProjectStatus.Pending, ProjectType.SYP, CurrentSchoolYear),
+        new("AI Study Buddy", "Lernassistent für Schüler mit Karteikarten, Quizfragen und KI-gestützten Erklärungen.", "C#, Python, OpenAI API, PostgreSQL", ProjectStatus.New, ProjectType.Diplomarbeit, CurrentSchoolYear),
+        new("VR Campus Tour", "Interaktive 3D-Tour durch Werkstätten, Labore und Medientechnik-Räume der Schule.", "Unity, Blender, C#", ProjectStatus.OnGoing, ProjectType.Diplomarbeit, CurrentSchoolYear),
+        new("Digital Signage System", "Zentrales System zur Anzeige von Stundenplanänderungen, Events und Projektinformationen auf Schulmonitoren.", "Angular, ASP.NET Core, Docker", ProjectStatus.New, ProjectType.SYP, CurrentSchoolYear),
+        new("Media Asset Manager", "Webbasierte Verwaltung von Fotos, Videos und Audio-Dateien für Medientechnik-Projekte.", "Angular, .NET, PostgreSQL, FFmpeg", ProjectStatus.Pending, ProjectType.SYP, CurrentSchoolYear),
+        new("Smart Lab Booking", "Reservierungssystem für Labore, Geräte und Workshop-Plätze mit Rollen- und Rechteverwaltung.", "ASP.NET Core, Entity Framework Core, Angular", ProjectStatus.OnGoing, ProjectType.SYP, "2024/25"),
+        new("Green School Monitor", "Dashboard für Energieverbrauch, Raumklima und Nachhaltigkeitsdaten der Schule.", "C#, MQTT, PostgreSQL, Angular", ProjectStatus.Completed, ProjectType.ProjectAward, "2024/25"),
+        new("Robotics Control Dashboard", "Browserbasiertes Dashboard zur Steuerung und Überwachung von Robotik-Demos.", "C#, SignalR, TypeScript", ProjectStatus.Completed, ProjectType.SYP, "2023/24"),
+        new("Event Check-in System", "QR-Code-basierte Anmeldung für Schulveranstaltungen mit Statistik-Auswertung.", "ASP.NET Core, Angular, PostgreSQL", ProjectStatus.Archived, ProjectType.SYP, "2023/24")
+    ];
+
+    public static async Task SeedAsync(IServiceProvider serviceProvider, IWebHostEnvironment environment, IConfiguration configuration)
+    {
+        var seedEnabled = configuration.GetValue("DemoData:SeedOnStartup", environment.IsDevelopment());
+        if (!seedEnabled)
+        {
+            return;
+        }
+
+        using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var csvPath = Path.Combine(environment.ContentRootPath, CsvFileName);
+        if (!File.Exists(csvPath))
+        {
+            return;
+        }
+
+        var students = await ReadStudentRowsAsync(csvPath);
+        if (students.Count == 0)
+        {
+            return;
+        }
+
+        await SeedSchoolYearsAsync(context);
+        await SeedStudentClassesAsync(context, students);
+        await SeedStudentsAsync(context, students);
+        await SeedStudentClassHistoriesAsync(context, students);
+        await SeedProfessorsAsync(context);
+        await SeedProjectsAsync(context, students);
+    }
+
+    private static async Task<IReadOnlyList<StudentSeedRow>> ReadStudentRowsAsync(string csvPath)
+    {
+        var lines = await File.ReadAllLinesAsync(csvPath);
+        if (lines.Length <= 1)
+        {
+            return [];
+        }
+
+        var headers = SplitCsvLine(lines[0], ';')
+            .Select(h => h.Replace("\uFEFF", string.Empty).Trim())
+            .ToList();
+
+        var rows = new List<StudentSeedRow>();
+        foreach (var line in lines.Skip(1).Where(l => !string.IsNullOrWhiteSpace(l)))
+        {
+            var values = SplitCsvLine(line, ';');
+            var row = headers
+                .Select((header, index) => new
+                {
+                    Header = header,
+                    Value = index < values.Count ? values[index].Trim() : string.Empty
+                })
+                .ToDictionary(x => x.Header, x => x.Value);
+
+            var department = GetValue(row, "Abteilung");
+            var className = GetValue(row, "Klasse");
+            var userName = GetValue(row, "EdufsUsername");
+            var firstName = GetValue(row, "Vorname");
+            var lastName = GetValue(row, "Nachname");
+
+            if (!IsRelevantDepartment(department) || !IsRelevantClass(className))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(userName) || string.IsNullOrWhiteSpace(firstName) || string.IsNullOrWhiteSpace(lastName))
+            {
+                continue;
+            }
+
+            rows.Add(new StudentSeedRow(
+                department,
+                className,
+                userName,
+                firstName,
+                lastName));
+        }
+
+        return rows
+            .DistinctBy(r => r.UserName, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(r => r.ClassName)
+            .ThenBy(r => r.LastName)
+            .ThenBy(r => r.FirstName)
+            .ToList();
+    }
+
+    private static async Task SeedSchoolYearsAsync(ApplicationDbContext context)
+    {
+        var existingYears = await context.SchoolYears
+            .Select(y => y.Year)
+            .ToListAsync();
+
+        var missingYears = SchoolYears
+            .Where(year => !existingYears.Contains(year, StringComparer.OrdinalIgnoreCase))
+            .Select(year => new SchoolYear { Year = year })
+            .ToList();
+
+        context.SchoolYears.AddRange(missingYears);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedStudentClassesAsync(ApplicationDbContext context, IReadOnlyList<StudentSeedRow> students)
+    {
+        var classCandidates = students
+            .SelectMany(BuildClassHistoryCandidates)
+            .DistinctBy(c => ClassKey(c.ClassName, c.Branch))
+            .ToList();
+
+        var existingClasses = await context.StudentClasses.ToListAsync();
+        var existingKeys = existingClasses
+            .Select(c => ClassKey(c.Name, c.Branch))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var newClasses = classCandidates
+            .Where(c => !existingKeys.Contains(ClassKey(c.ClassName, c.Branch)))
+            .Select(c => new StudentClass { Name = c.ClassName, Branch = c.Branch })
+            .ToList();
+
+        context.StudentClasses.AddRange(newClasses);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedStudentsAsync(ApplicationDbContext context, IReadOnlyList<StudentSeedRow> students)
+    {
+        var ids = students.Select(s => s.UserName).ToList();
+        var existingIds = await context.Students
+            .Where(s => ids.Contains(s.Id))
+            .Select(s => s.Id)
+            .ToListAsync();
+
+        var existingIdSet = existingIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var newStudents = students
+            .Where(s => !existingIdSet.Contains(s.UserName))
+            .Select(s => new Student
+            {
+                Id = s.UserName,
+                FirstName = s.FirstName,
+                LastName = s.LastName
+            })
+            .ToList();
+
+        context.Students.AddRange(newStudents);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedStudentClassHistoriesAsync(ApplicationDbContext context, IReadOnlyList<StudentSeedRow> students)
+    {
+        var schoolYearList = await context.SchoolYears.ToListAsync();
+        var schoolYears = schoolYearList.ToDictionary(y => y.Year, StringComparer.OrdinalIgnoreCase);
+        var classes = await context.StudentClasses.ToListAsync();
+        var classesByKey = classes.ToDictionary(c => ClassKey(c.Name, c.Branch), StringComparer.OrdinalIgnoreCase);
+        var existingHistoryKeys = await context.StudentClassHistories
+            .Select(h => new { h.StudentId, h.ClassId, h.SchoolYearId })
+            .ToListAsync();
+
+        var existingKeys = existingHistoryKeys
+            .Select(h => HistoryKey(h.StudentId, h.ClassId, h.SchoolYearId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var histories = new List<StudentClassHistory>();
+        foreach (var student in students)
+        {
+            foreach (var candidate in BuildClassHistoryCandidates(student))
+            {
+                if (!schoolYears.TryGetValue(candidate.SchoolYear, out var schoolYear))
+                {
+                    continue;
+                }
+
+                if (!classesByKey.TryGetValue(ClassKey(candidate.ClassName, candidate.Branch), out var studentClass))
+                {
+                    continue;
+                }
+
+                var key = HistoryKey(student.UserName, studentClass.Id, schoolYear.Id);
+                if (existingKeys.Contains(key))
+                {
+                    continue;
+                }
+
+                histories.Add(new StudentClassHistory
+                {
+                    StudentId = student.UserName,
+                    ClassId = studentClass.Id,
+                    SchoolYearId = schoolYear.Id
+                });
+                existingKeys.Add(key);
+            }
+        }
+
+        context.StudentClassHistories.AddRange(histories);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedProfessorsAsync(ApplicationDbContext context)
+    {
+        var ids = DemoProfessors.Select(p => p.Id).ToList();
+        var existingIds = await context.Professors
+            .Where(p => ids.Contains(p.Id))
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        var existingIdSet = existingIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var newProfessors = DemoProfessors
+            .Where(p => !existingIdSet.Contains(p.Id))
+            .Select(p => new Professor
+            {
+                Id = p.Id,
+                FirstName = p.FirstName,
+                LastName = p.LastName
+            })
+            .ToList();
+
+        context.Professors.AddRange(newProfessors);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedProjectsAsync(ApplicationDbContext context, IReadOnlyList<StudentSeedRow> students)
+    {
+        var existingProjectTitles = await context.Projects
+            .Select(p => p.Title)
+            .ToListAsync();
+
+        var existingTitleSet = existingProjectTitles.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var newProjects = DemoProjects
+            .Where(p => !existingTitleSet.Contains(p.Title))
+            .Select(p => new Project
+            {
+                Title = p.Title,
+                Description = p.Description,
+                Technology = p.Technology,
+                Status = p.Status,
+                ProjectType = p.ProjectType
+            })
+            .ToList();
+
+        context.Projects.AddRange(newProjects);
+        await context.SaveChangesAsync();
+
+        var projectTitles = DemoProjects.Select(d => d.Title).ToList();
+        var projects = await context.Projects
+            .Where(p => projectTitles.Contains(p.Title))
+            .ToListAsync();
+        var projectsByTitle = projects.ToDictionary(p => p.Title, StringComparer.OrdinalIgnoreCase);
+        var schoolYearList = await context.SchoolYears.ToListAsync();
+        var schoolYears = schoolYearList.ToDictionary(y => y.Year, StringComparer.OrdinalIgnoreCase);
+
+        await SeedSchoolYearProjectsAsync(context, projectsByTitle, schoolYears);
+        await SeedProjectSupervisorsAsync(context, projectsByTitle);
+        await SeedProjectStudentsAsync(context, projectsByTitle, students);
+    }
+
+    private static async Task SeedSchoolYearProjectsAsync(
+        ApplicationDbContext context,
+        IReadOnlyDictionary<string, Project> projectsByTitle,
+        IReadOnlyDictionary<string, SchoolYear> schoolYears)
+    {
+        var existingKeys = await context.SchoolYearProjects
+            .Select(p => new { p.ProjectId, p.SchoolYearId })
+            .ToListAsync();
+
+        var existingKeySet = existingKeys
+            .Select(p => SchoolYearProjectKey(p.ProjectId, p.SchoolYearId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var schoolYearProjects = DemoProjects
+            .Where(p => projectsByTitle.ContainsKey(p.Title) && schoolYears.ContainsKey(p.SchoolYear))
+            .Select(p => new
+            {
+                Project = projectsByTitle[p.Title],
+                SchoolYear = schoolYears[p.SchoolYear]
+            })
+            .Where(p => !existingKeySet.Contains(SchoolYearProjectKey(p.Project.Id, p.SchoolYear.Id)))
+            .Select(p => new SchoolYearProject
+            {
+                ProjectId = p.Project.Id,
+                SchoolYearId = p.SchoolYear.Id
+            })
+            .ToList();
+
+        context.SchoolYearProjects.AddRange(schoolYearProjects);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedProjectSupervisorsAsync(ApplicationDbContext context, IReadOnlyDictionary<string, Project> projectsByTitle)
+    {
+        var existingKeys = await context.ProjectSupervisors
+            .Select(p => new { p.ProjectId, p.ProfessorId })
+            .ToListAsync();
+
+        var existingKeySet = existingKeys
+            .Select(p => ProjectSupervisorKey(p.ProjectId, p.ProfessorId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var supervisors = new List<ProjectSupervisor>();
+        for (var i = 0; i < DemoProjects.Length; i++)
+        {
+            var projectSeed = DemoProjects[i];
+            if (!projectsByTitle.TryGetValue(projectSeed.Title, out var project))
+            {
+                continue;
+            }
+
+            var mainProfessor = DemoProfessors[i % DemoProfessors.Length];
+            var secondProfessor = DemoProfessors[(i + 3) % DemoProfessors.Length];
+
+            AddSupervisor(supervisors, existingKeySet, project.Id, mainProfessor.Id, "Main supervisor");
+            AddSupervisor(supervisors, existingKeySet, project.Id, secondProfessor.Id, "Co-supervisor");
+        }
+
+        context.ProjectSupervisors.AddRange(supervisors);
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedProjectStudentsAsync(
+        ApplicationDbContext context,
+        IReadOnlyDictionary<string, Project> projectsByTitle,
+        IReadOnlyList<StudentSeedRow> students)
+    {
+        var currentSchoolYear = await context.SchoolYears.SingleAsync(y => y.Year == CurrentSchoolYear);
+        var currentHistories = await context.StudentClassHistories
+            .Include(h => h.StudentClass)
+            .Where(h => h.SchoolYearId == currentSchoolYear.Id)
+            .ToListAsync();
+
+        var historyByStudentId = currentHistories.ToDictionary(h => h.StudentId, StringComparer.OrdinalIgnoreCase);
+        var existingKeys = await context.ProjectStudents
+            .Select(p => new { p.ProjectId, p.HistoryId })
+            .ToListAsync();
+
+        var existingKeySet = existingKeys
+            .Select(p => ProjectStudentKey(p.ProjectId, p.HistoryId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var assignmentProjects = DemoProjects
+            .Where(p => p.SchoolYear == CurrentSchoolYear)
+            .Where(p => projectsByTitle.ContainsKey(p.Title))
+            .Select(p => projectsByTitle[p.Title])
+            .ToList();
+
+        if (assignmentProjects.Count == 0)
+        {
+            return;
+        }
+
+        var studentAssignments = students
+            .Where(s => historyByStudentId.ContainsKey(s.UserName))
+            .OrderBy(s => s.ClassName)
+            .ThenBy(s => s.LastName)
+            .ThenBy(s => s.FirstName)
+            .Select((student, index) => new
+            {
+                Student = student,
+                Project = assignmentProjects[index % assignmentProjects.Count]
+            })
+            .ToList();
+
+        var projectStudents = new List<ProjectStudent>();
+        foreach (var assignment in studentAssignments)
+        {
+            var history = historyByStudentId[assignment.Student.UserName];
+            var key = ProjectStudentKey(assignment.Project.Id, history.Id);
+            if (existingKeySet.Contains(key))
+            {
+                continue;
+            }
+
+            projectStudents.Add(new ProjectStudent
+            {
+                ProjectId = assignment.Project.Id,
+                HistoryId = history.Id,
+                Role = GetStudentRole(assignment.Student.ClassName)
+            });
+            existingKeySet.Add(key);
+        }
+
+        context.ProjectStudents.AddRange(projectStudents);
+        await context.SaveChangesAsync();
+    }
+
+    private static IEnumerable<ClassHistoryCandidate> BuildClassHistoryCandidates(StudentSeedRow student)
+    {
+        var currentGrade = GetGrade(student.ClassName);
+        if (currentGrade is null)
+        {
+            yield break;
+        }
+
+        var schoolYearsForStudent = SchoolYears.Reverse().ToList();
+        for (var offset = 0; offset < schoolYearsForStudent.Count; offset++)
+        {
+            var grade = currentGrade.Value - offset;
+            if (grade < 3)
+            {
+                break;
+            }
+
+            yield return new ClassHistoryCandidate(
+                schoolYearsForStudent[offset],
+                ReplaceGrade(student.ClassName, grade),
+                student.Department);
+        }
+    }
+
+    private static void AddSupervisor(
+        List<ProjectSupervisor> supervisors,
+        ISet<string> existingKeys,
+        int projectId,
+        string professorId,
+        string role)
+    {
+        var key = ProjectSupervisorKey(projectId, professorId);
+        if (existingKeys.Contains(key))
+        {
+            return;
+        }
+
+        supervisors.Add(new ProjectSupervisor
+        {
+            ProjectId = projectId,
+            ProfessorId = professorId,
+            Role = role
+        });
+        existingKeys.Add(key);
+    }
+
+    private static string GetStudentRole(string className)
+    {
+        var grade = GetGrade(className);
+        return grade switch
+        {
+            5 => "Diploma project member",
+            4 => "Project member",
+            _ => "Junior project member"
+        };
+    }
+
+    private static bool IsRelevantDepartment(string department) =>
+        department.Equals("Informatik", StringComparison.OrdinalIgnoreCase) ||
+        department.Equals("Medientechnik", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsRelevantClass(string className)
+    {
+        var grade = GetGrade(className);
+        return grade is >= 3 and <= 5 && !className.Contains("FS", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int? GetGrade(string className)
+    {
+        if (string.IsNullOrWhiteSpace(className) || !char.IsDigit(className[0]))
+        {
+            return null;
+        }
+
+        return int.Parse(className[0].ToString(), CultureInfo.InvariantCulture);
+    }
+
+    private static string ReplaceGrade(string className, int grade) =>
+        className.Length == 0 ? className : $"{grade}{className[1..]}";
+
+    private static List<string> SplitCsvLine(string line, char delimiter)
+    {
+        var result = new List<string>();
+        var current = new List<char>();
+        var inQuotes = false;
+
+        for (var i = 0; i < line.Length; i++)
+        {
+            var c = line[i];
+            if (c == '"')
+            {
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    current.Add('"');
+                    i++;
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
+            }
+            else if (c == delimiter && !inQuotes)
+            {
+                result.Add(new string(current.ToArray()));
+                current.Clear();
+            }
+            else
+            {
+                current.Add(c);
+            }
+        }
+
+        result.Add(new string(current.ToArray()));
+        return result;
+    }
+
+    private static string GetValue(IReadOnlyDictionary<string, string> row, string key) =>
+        row.TryGetValue(key, out var value) ? value.Trim() : string.Empty;
+
+    private static string ClassKey(string className, string branch) =>
+        $"{className.Trim().ToUpperInvariant()}|{branch.Trim().ToUpperInvariant()}";
+
+    private static string HistoryKey(string studentId, int classId, int schoolYearId) =>
+        $"{studentId.Trim().ToUpperInvariant()}|{classId}|{schoolYearId}";
+
+    private static string SchoolYearProjectKey(int projectId, int schoolYearId) =>
+        $"{projectId}|{schoolYearId}";
+
+    private static string ProjectSupervisorKey(int projectId, string professorId) =>
+        $"{projectId}|{professorId.Trim().ToUpperInvariant()}";
+
+    private static string ProjectStudentKey(int projectId, int historyId) =>
+        $"{projectId}|{historyId}";
+
+    private record StudentSeedRow(string Department, string ClassName, string UserName, string FirstName, string LastName);
+
+    private record ClassHistoryCandidate(string SchoolYear, string ClassName, string Branch);
+
+    private record DemoProfessor(string Id, string FirstName, string LastName);
+
+    private record DemoProject(
+        string Title,
+        string Description,
+        string Technology,
+        ProjectStatus Status,
+        ProjectType ProjectType,
+        string SchoolYear);
+}

--- a/backend/WebApplication/WebAPI/WebAPI.csproj
+++ b/backend/WebApplication/WebAPI/WebAPI.csproj
@@ -21,6 +21,12 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="SeedData\2025-11-Tadeot-Assignments.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/backend/WebApplication/WebAPI/appsettings.Development.json
+++ b/backend/WebApplication/WebAPI/appsettings.Development.json
@@ -8,8 +8,8 @@
     ]
   },
   "Authentication": {
-    "Authority": "https://auth.htl-leonding.ac.at/realms/htlleonding",
-    "Audience": "htlleonding-service",
+    "Authority": "",
+    "Audience": "school-management-frontend",
     "RequireHttpsMetadata": false
   },
   "Logging": {
@@ -17,5 +17,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "DemoData": {
+    "SeedOnStartup": true
   }
 }


### PR DESCRIPTION
Implemented issue #27.

Changes:
- Added automatic demo data seeding for development.
- Added multiple school years.
- Added classes for multiple school years.
- Imported demo students from the provided CSV.
- Filtered CSV data to Informatik and Medientechnik students from 3rd to 5th grade.
- Added StudentClassHistory entries for the seeded students.
- Added demo professors.
- Added realistic demo projects with title, description, status, technologies and project type.
- Assigned students and supervisors to projects.
- Kept existing data safe by skipping already existing records instead of overwriting them.

Closes #27